### PR TITLE
April 1st - Time Series Data Cleaning Updated

### DIFF
--- a/COVID-19/COVID-19 Data/COVID-19 Daily/Create_Matrix.py
+++ b/COVID-19/COVID-19 Data/COVID-19 Daily/Create_Matrix.py
@@ -1,13 +1,13 @@
 ################################################################
 ################################################################
 ### Thomas Merkh, tmerkh@g.ucla.edu
-### 3.22.2020
+### 4.1.2020
 ################################################################
 ### 
 ### This code parses data found at https://github.com/CSSEGISandData/COVID-19, which in turn is being used for the interactive interface found at https://plague.com/
 ### Original data sources: WHO, CDC, ECDC, NHC, DXY, 1point3acres, Worldometers.info, BNO, state and national government health department, and local media reports.
 ### 
-### The resulting data matrix is(are) stored as a .mat file.
+### The resulting data matrices are stored as a .mat files.
 ###
 ### Each row is a region, i.e. Hawaii, US.  The row information for each matrix row is contained in the corresponding file ending in '_row_info.txt'
 ### Each column corresponds to a particular date (sequential).  The date information can be found in the corresponding file ending in '_col_names.txt'
@@ -16,7 +16,8 @@
 ### 
 ################################################################
 ### To run this:  The user needs to set the filepath correctly, this can be seen below where this Python program is being held outside the COVID19master folder downloadable from Github
-### As the number of dates change, and possibly the number of locations being reported on, the size of the data matrix must change accordingly. 
+### The updated dataset as of the March 23rd has changed so that the naming conventions for deaths vs. confirmed vs recovered, global vs USA are basically all different. 
+### This updated script takes this into account. 
 ################################################################
 ################################################################
 
@@ -24,18 +25,52 @@ import sys, os
 import numpy as np
 import scipy.io
 
-cwd = os.getcwd()
-print(cwd)
+#############################################################################
+############## User - Please choose which extension 0, 1, or 2 ##############
+#############################################################################
 
-extensions = ["Confirmed","Deaths","Recovered"] # The endings of the 3 data files
-extension  = extensions[0]                      # Done this way since the extension gets used later to save the matrix
+extensions = ["confirmed","deaths","recovered"] # The endings of the 3 data files
+extension  = extensions[2]                      # Done this way since the extension gets used later to save the matrix
 
-filepath = cwd + "\\COVID19master\\csse_covid_19_data\\csse_covid_19_time_series\\time_series_19-covid-" + extension + ".csv"
+#############################################################################
+#############################################################################
+#############################################################################
+
+# I set the file path by hand, one may use os.getcwd() to obtain the current working directory
+filepath = "/home/tmerkh/CSSEGISandData/COVID-19/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_" + extension + "_global.csv"
+
+# this is in place since recovered USA data is not available (as of april 1st 2020)
+if(extension != "recovered"):
+    filepath2 = "/home/tmerkh/CSSEGISandData/COVID-19/csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_" + extension + "_US.csv"
+
+lcount  = 0
+lcount2 = 0
+with open(filepath, 'rt') as myfile:
+    for line in myfile:
+        if(lcount == 1):
+            N_Days = len(line.split(","))-4  # There are 4 entries in each row which aren't dates
+        lcount += 1
+
+if(extension != "recovered"):
+    with open(filepath2, 'rt') as myfile:
+        for line in myfile:
+            if(lcount2 == 0):
+                if(extension == "confirmed"):
+                    N_Days2 = len(line.split(","))-11 # There are 11 entries in each row which aren't dates for confirmed
+                elif (extension == "deaths"):
+                    N_Days2 = len(line.split(","))-12 # There are 12 entries in each row which aren't dates for deaths    
+            lcount2 += 1
 
 col_names = []
-row_info = []                # Holds lists containing information about each row of the data matrix 
-data = np.zeros((483,60))    # 483 regions reported on, 60 days for each
+row_info  = []
+data = np.zeros((lcount,N_Days))    # regions = rows, N_days :: global data
 
+if(extension != "recovered"):
+    col_names2 = []
+    row_info2  = [] 
+    data2 = np.zeros((lcount2,N_Days2))    # regions = rows, N_days :: USA data
+
+# Global
 with open(filepath, 'rt') as myfile:
     lcount = 1
     for line in myfile:
@@ -52,15 +87,49 @@ with open(filepath, 'rt') as myfile:
             row_info.append(linelist[:4])
         lcount += 1
 
-#print(col_names)
-#print(data)
-#print(row_info)
+# USA
+if(extension != "recovered"):
+    with open(filepath2, 'rt') as myfile:
+        lcount2 = 1
+        for line in myfile:
+            line = line.strip("\n")
+            if(lcount2 == 1):
+                col_names2 = line.split(",")
+            else:
+                if(extension == "confirmed"):
+                    linelist = line.split(",")
+                    linelist_fixed = linelist[:10] + [str(linelist[10]+linelist[11]).strip('"')] + linelist[13:]
+                    linelist = linelist_fixed
+                    while(len(linelist[11:]) < N_Days2):
+                        linelist.append('0')
+                    data2[lcount2-1,:] = np.asarray([int(i) for i in linelist[11:]])
+                    row_info2.append(linelist[:11])
 
-## Save the data:
 
-scipy.io.savemat(extension + ".mat", {extension : data})
+                elif(extension == "deaths"):
+                    linelist = line.split(",")
+                    linelist_fixed = linelist[:10] + [str(linelist[10]+linelist[11]+linelist[12]).strip('"')] + linelist[13:]
+                    linelist = linelist_fixed
+                    if(len(linelist) == len(col_names2)):
+                        data2[lcount2-1,:] = np.asarray([int(i) for i in linelist[12:]])
+                        row_info2.append(linelist[:12])
+            lcount2 += 1
 
-MyFile = open(extension + '_col_names.txt','w')
+## Save the data
+cwd = os.getcwd()
+
+# Make sure that the directory already exists
+if not(os.path.isdir(cwd + "/TimeSeriesMatrices")):
+    print("Creating TimeSeriesMatrices")
+    os.mkdir(cwd + "/TimeSeriesMatrices")
+os.chdir("TimeSeriesMatrices")
+
+
+## Global First
+
+scipy.io.savemat(extension + "global.mat", {extension+"global" : data})
+
+MyFile = open(extension + '_col_names_global.txt','w')
 for i in range(len(col_names)):
     if(i != len(col_names)-1):
         MyFile.write(col_names[i]+", ")
@@ -68,7 +137,7 @@ for i in range(len(col_names)):
         MyFile.write(col_names[i])
 MyFile.close()
 
-MyFile = open(extension + '_row_info.txt','w')
+MyFile = open(extension + '_row_info_global.txt','w')
 for i in range(len(row_info)):
     if(i != len(row_info)-1):
         for j in range(len(row_info[i])):
@@ -84,4 +153,32 @@ for i in range(len(row_info)):
                 MyFile.write(row_info[i][j])
 MyFile.close()
 
+
+## USA now
+if(extension != "recovered"):
+    scipy.io.savemat(extension + "USA.mat", {extension+"USA" : data2})
+    MyFile = open(extension + '_col_names_USA.txt','w')
+    for i in range(len(col_names2)):
+        if(i != len(col_names2)-1):
+            MyFile.write(col_names2[i]+", ")
+        else:
+            MyFile.write(col_names2[i])
+    MyFile.close()
+    
+    MyFile = open(extension + '_row_info_USA.txt','w')
+    for i in range(len(row_info2)):
+        if(i != len(row_info2)-1):
+            for j in range(len(row_info2[i])):
+                if(j != len(row_info2[i])-1):
+                    MyFile.write(row_info2[i][j]+", ")
+                else:
+                    MyFile.write(row_info2[i][j]+'\n')
+        else:
+            for j in range(len(row_info2[i])):
+                if(j != len(row_info2[i])-1):
+                    MyFile.write(row_info2[i][j]+", ")
+                else:
+                    MyFile.write(row_info2[i][j])
+    MyFile.close()
+os.chdir("..")
 print("Program completed")


### PR DESCRIPTION
The github repository containing the "messy" time series data for covid deaths, recovered, and confirmed cases added additional data sets (US specific with more explicit regions), and they changed their naming conventions for previous data sets.  This overhaul takes into these changes and now generates time series matrices for global and USA data, plus it automated one part of the code which was previously lazily not implemented.  